### PR TITLE
Add gistify method to Publish class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ site/
 Jupyter to Medium Initial Post_files/
 Jupyter to Medium Initial Post_medium.md
 *_files/
+notebooks/

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Do you ....
 * Publish blog posts on Medium?
 * Use Jupyter Notebooks to write your posts?
 * Dislike the time and effort it takes to transfer your posts from Jupyter to Medium?
+* Get lost/bored when switching between the medium editor, gist etc to create well linted code?
 
 If so, jupyter_to_medium will automate the process of taking your Jupyter Notebook, as is, and publishing it as a Medium post in almost no time at all saving huge amounts of time.
 
@@ -47,6 +48,12 @@ Once your request to create integration tokens is accepted, navigate to <a href=
 ### Save your integration token
 
 Once you have your integration token, create the folder and file `.jupyter_to_medium/integration_token` in your home directory and save the token there. If you don't save it, you'll need to access it every time you wish to make a new post.
+
+### Create / save your github PAT (only required for gist integration)
+
+When publishing, jtm can take unformatted code snippets and replace them with [linted gists](https://gist.github.com/mjam03/761d017e821b62c3adf2d4cf1b7477d3). In order to do this, it needs to create the gists which requires github access as well as a Personal Access Token (PAT). To create a github account, sign up [here](https://github.com/) and then follow [these instructions](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) to create a PAT - __ensure to select the option for creating gists__.
+
+Once you have your Github PAT, similar to the integration token, create the folder and file `.jupyter_to_medium/github_token` in your home directory and save the token there. If you don't save it, you'll need to access it every time you wish to make a new post.
 
 ## Usage
 
@@ -103,7 +110,8 @@ jtm.publish('My Awesome Jupyter Notebook.ipynb',
             canonical_url=None,
             chrome_path=None,
             save_markdown=False,
-            table_conversion='chrome'
+            table_conversion='chrome',
+            gistify=False
             )
 ```
 

--- a/jupyter_to_medium/__init__.py
+++ b/jupyter_to_medium/__init__.py
@@ -1,5 +1,6 @@
 from ._publish_to_medium import publish
-__version__ = '0.2.4'
+__version__ = '0.2.5'
+
 
 def _jupyter_nbextension_paths():
     return [dict(

--- a/jupyter_to_medium/_bundler.py
+++ b/jupyter_to_medium/_bundler.py
@@ -19,7 +19,8 @@ def _jupyter_bundlerextension_paths():
 def upload(model, handler):
     arguments = ['title', 'integration_token', 'pub_name', 'tags',
                  'publish_status', 'notify_followers', 'license', 'canonical_url',
-                 'chrome_path', 'save_markdown', 'table_conversion', 'gistify']
+                 'chrome_path', 'save_markdown', 'table_conversion', 'gistify',
+                 'gist_threshold']
 
     kwargs = {arg: handler.get_query_argument(arg, None) for arg in arguments}
     path = model['path']
@@ -31,6 +32,7 @@ def upload(model, handler):
     kwargs['canonical_url'] = kwargs['canonical_url'].strip() or None
     kwargs['save_markdown'] = kwargs['save_markdown'] == "True"
     kwargs['gistify'] = kwargs['gistify'] == "True"
+    kwargs['gist_threshold'] = int(kwargs['gist_threshold'])
 
     # add these options in the future to html form
     # kwargs['chrome_path'] = kwargs['chrome_path'].strip() or None

--- a/jupyter_to_medium/_bundler.py
+++ b/jupyter_to_medium/_bundler.py
@@ -11,14 +11,15 @@ def _jupyter_bundlerextension_paths():
     return [{
         "name": "jupyter_to_medium_bundler",
         "module_name": "jupyter_to_medium._bundler",
-        "label" : "Medium Post",
-        "group" : "deploy",
+        "label": "Medium Post",
+        "group": "deploy",
     }]
 
+
 def upload(model, handler):
-    arguments = ['title', 'integration_token', 'pub_name', 'tags', 
-                'publish_status', 'notify_followers', 'license', 'canonical_url',
-                'chrome_path', 'save_markdown', 'table_conversion']
+    arguments = ['title', 'integration_token', 'pub_name', 'tags',
+                 'publish_status', 'notify_followers', 'license', 'canonical_url',
+                 'chrome_path', 'save_markdown', 'table_conversion', 'gistify']
 
     kwargs = {arg: handler.get_query_argument(arg, None) for arg in arguments}
     path = model['path']
@@ -29,10 +30,11 @@ def upload(model, handler):
     kwargs['notify_followers'] = kwargs['notify_followers'] == "True"
     kwargs['canonical_url'] = kwargs['canonical_url'].strip() or None
     kwargs['save_markdown'] = kwargs['save_markdown'] == "True"
+    kwargs['gistify'] = kwargs['gistify'] == "True"
 
     # add these options in the future to html form
     # kwargs['chrome_path'] = kwargs['chrome_path'].strip() or None
-   
+
     try:
         data = publish(**kwargs)
     except Exception as e:
@@ -43,31 +45,35 @@ def upload(model, handler):
         msg = error + f'\n\n{tb}'
         print(msg)
         msg = msg.replace('\n', '<br>')
-        
-        data = {'app_status': 'fail', 
+
+        data = {'app_status': 'fail',
                 'error_data': msg}
     else:
         if 'data' in data:
             data = data['data']
             data['app_status'] = "success"
         else:
-            data = {'app_status': 'fail', 
+            data = {'app_status': 'fail',
                     'error_data': 'Error: \n' + str(data)}
 
     return data
+
 
 def read_html(name):
     mod_path = Path(__file__).parent
     html_path = mod_path / 'static' / f'{name}.html'
     return open(html_path).read()
 
+
 def get_html_form(xsrf_input, title):
     html = read_html('form')
     return html.format(xsrf_input=xsrf_input, title=title)
 
+
 def get_html_success(data):
     html = read_html('success')
     return html.format(**data)
+
 
 def get_html_fail(data):
     error_data = data['error_data']
@@ -87,7 +93,7 @@ def bundle(handler, model):
         Notebook model from the configured ContentManager
     """
     app_status = handler.get_query_argument('app_status', None)
-    
+
     if app_status is None:
         xsrf_input = handler.xsrf_form_html()
         notebook_filename = Path(model['name']).stem
@@ -102,8 +108,7 @@ def bundle(handler, model):
             html = get_html_success(data)
         else:
             html = get_html_fail(data)
-        
+
         handler.write(html)
 
     handler.finish()
-  

--- a/jupyter_to_medium/_postprocessors.py
+++ b/jupyter_to_medium/_postprocessors.py
@@ -1,0 +1,185 @@
+import json
+from pathlib import Path
+import requests
+import uuid
+
+
+def write_file(file_name, new_content):
+    f = open(file_name, "w")
+    f.write(new_content)
+    f.close()
+
+
+def get_github_api_token(tok):
+    '''
+    Fetch github personal access token (PAT) for gist api request using POST
+
+    Parameters
+    ----------
+    tok : str
+        PAT if passed as string, else None and will be fetched
+    '''
+    if not tok:
+        tok_path = Path.home() / '.jupyter_to_medium' / 'github_token'
+        tok = open(tok_path).read().splitlines()[0]
+    return tok
+
+
+def get_formatted_gist_code(response, output_type):
+    '''
+    Parse gist api response and return desired output
+    For medium, this is an http url for embedded the gist
+
+    Parameters
+    ----------
+    response : json
+        gist api response from the POST request to create gist
+    output_type: str
+        desired publication name
+    '''
+    if output_type == 'hugo':
+        owner = response['owner']['login']
+        id = response['id']
+        short_code = '{{< gist '+owner+' '+id+' >}}'
+        return short_code
+    else:
+        return response['html_url']
+
+
+def create_gist(title, description, content, output_type='medium', github_token=None):
+    '''
+    Takes code string, creates gist, returns url for publication embedding
+    Can see git ref here: https://docs.github.com/en/rest/reference/gists#create-a-gist
+
+    Parameters
+    ----------
+    title : str
+        gist title - by default a random uuid with notebook lang ext (e.g. .py)
+        added so gist has desired linting
+    description: str
+        gist description - by default the space-stripped notebook title with _n
+        e.g. 'My New Article' --> MyNewArticle_0 for first gist in notebook
+    content: str
+        str code block to be made into gist from markdown
+    output_type: str
+        desired publication name
+    github_token: str
+        can pass github personal access token else defaults to ~/.jupyter_to_medium/github_token
+    '''
+    GITHUB_API = "https://api.github.com"
+    try:
+        API_TOKEN = get_github_api_token(github_token)
+    except Exception as e:
+        raise ValueError(
+            'Problem fetching Github Token \n Ensure it is located in ~/.jupyter_to_medium/github_token')
+
+    # form a request URL
+    url = GITHUB_API+"/gists"
+    # headers, parameters, payload
+    headers = {'Authorization': 'token %s' % API_TOKEN}
+    params = {'scope': 'gist'}
+    payload = {
+        "description": description,
+        "public": True,
+        "files": {title: {
+            "content": content
+        }}
+    }
+    # make a request
+    res = requests.post(url, headers=headers, params=params,
+                        data=json.dumps(payload))
+    # if 201 response, then proceed, else fail with error
+    try:
+        # success with gist creation
+        j = json.loads(res.text)
+        output = get_formatted_gist_code(j, output_type)
+    except Exception as e:
+        raise ValueError('Problem with gistify-ing:\n' + res.text)
+
+    return output
+
+
+def gist_namer(art_title, num):
+    '''
+    Create formatted gist name to help with grouping gists
+
+    Parameters
+    ----------
+    art_title : str
+        defaults to the notebook name
+    num: int
+        gist count for this article e.g. first gist of article is 0
+    '''
+    # lower case and snake_case the whole thing
+    title = art_title.lower().replace(' ', '_')
+    title += str(num)
+    return title
+
+
+def gistPostprocessor(markdown_list, art_title, lang_ext='.py', output_type='medium', gist_threshold=5):
+    '''
+    Iterate over listify'ed markdown, identify code blocks, insert gist http instead
+    Overall to remove unlinted codeblocks from .md for medium publication
+    To be called after converting an .ipynb to .md format
+
+    Parameters
+    ----------
+    markdown_list : list
+        list of strings created by \n splitting a standard .md document
+    art_title: str
+        title of the article - used to describe gists
+    output_type: str
+        desired publication name e.g. 'medium'
+    gist_threshold: int
+        only gistify code snippets with a line length greater than this
+    '''
+
+    gist_dict = {}
+    new_md_str = ''
+    code_block_started = False
+    code_block = []
+    gist_count = 0
+    code_block_length = 0
+
+    for line in markdown_list:
+        if line.startswith('```') and not code_block_started:
+            # we must have the start of a new code block
+            code_block_started = True
+        elif line.startswith('```') and code_block_started:
+            # we must have the end of a code block
+            # check if code block is greater than threshold
+            if len(code_block) > gist_threshold:
+                # convert code block list to string
+                code_block = ''.join(code_block)
+                # let's replace it with a gist
+                # time to gistify the code we have
+                gist_name = gist_namer(art_title, gist_count)
+                short_code = create_gist(str(uuid.uuid4())+lang_ext,
+                                         gist_name,
+                                         code_block,
+                                         output_type)
+                # now add to our new md string
+                new_md_str += "\n" + short_code + "\n"
+                # update gist_dict
+                gist_dict[short_code] = code_block
+                # update gist count
+                gist_count += 1
+            else:
+                # let's keep it as it is, we need to add back the ```
+                code_block = ''.join(code_block)
+                new_md_str += '```\n' + code_block + '```\n'
+            # reset our looping vars
+            code_block_length = 0
+            code_block = []
+            code_block_started = False
+        elif code_block_started:
+            # add code to the code_block until we hit the end of the block
+            # increment block length
+            code_block.append(line)
+            code_block_length += 1
+        else:
+            # non-code markdown so just add it
+            new_md_str += line
+
+    # return our new markdown and the gist_dict
+    return new_md_str, gist_dict

--- a/jupyter_to_medium/_publish_to_medium.py
+++ b/jupyter_to_medium/_publish_to_medium.py
@@ -222,10 +222,9 @@ class Publish:
         if self.tags:
             json_data['tags'] = self.tags
 
-        # add timeout of 1minute to prevent timeout response for large articles
+        # add timeout of 30 seconds to prevent timeout response for large articles
         req = requests.post(post_url, headers=self.headers,
-                            json=json_data, timeout=60)
-        print(req.elapsed)
+                            json=json_data, timeout=30)
         try:
             self.result = req.json()
         except Exception as e:

--- a/jupyter_to_medium/static/form.html
+++ b/jupyter_to_medium/static/form.html
@@ -159,6 +159,32 @@
             </fieldset>
 
             <fieldset class="form-group">
+              <div class="row">
+                <legend class="col-form-label col-sm-2 pt-0">Gistify Markdown</legend>
+                <div class="col-sm-8">
+                  <div class="form-check form-check-inline">
+                    <input class="form-check-input" type="radio" name="gistify" 
+                           id="yes_gist_md" value="True">
+                    <label class="form-check-label" for="yes_gist_md">
+                      Yes
+                    </label>
+                  </div>
+                  <div class="form-check form-check-inline">
+                    <input class="form-check-input" type="radio" name="gistify" 
+                           id="no_gist_md" value="False" checked="checked">
+                    <label class="form-check-label" for="no_gist_md">
+                      No
+                    </label>
+                  </div>
+                  <small class="form-text text-muted">If selected, codeblocks will be replaced by embedded
+                     links to a gist (per code block). This allows code to show in your medium post with 
+                     python linting. To do so requires you have a github account and github PAT (instructions
+                     found in the jupyter_to_medium instructions.</small>
+                </div>
+              </div>
+          </fieldset>
+
+            <fieldset class="form-group">
                 <div class="row">
                   <legend class="col-form-label col-sm-2 pt-0">Table Conversion</legend>
                   <div class="col-sm-8">

--- a/jupyter_to_medium/static/form.html
+++ b/jupyter_to_medium/static/form.html
@@ -182,7 +182,17 @@
                      found in the jupyter_to_medium instructions.</small>
                 </div>
               </div>
-          </fieldset>
+            </fieldset>
+
+            <div class="form-group row">
+              <label for="title" class="col-sm-2 col-form-label">Gist Threshold</label>
+              <div class="col-sm-8">
+                  <input type="text" class="form-control" name="gist_threshold" id="gist_threshold" placeholder="5">
+                  <small class="form-text text-muted">Code blocks greater than this threshold number of lines
+                     will be replaced with gists if you have selected the above 'gistify' option.
+                  </small>
+              </div>
+            </div>
 
             <fieldset class="form-group">
                 <div class="row">

--- a/tests/test_post.py
+++ b/tests/test_post.py
@@ -1,8 +1,12 @@
 import pytest
 import jupyter_to_medium as jtm
 
-
 class TestPost:
 
     def test_post(self):
         jtm.publish('tests/notebooks/Test Medium Blog Post.ipynb')
+
+
+# def gistify_test_post():
+#    p = publish('tests/notebooks/Test Medium Blog Post.ipynb', gistify=True)
+#    return p

--- a/tests/test_post.py
+++ b/tests/test_post.py
@@ -1,12 +1,14 @@
 import pytest
 import jupyter_to_medium as jtm
 
+
+def test_gistify_post():
+    p = jtm.publish(
+        'tests/notebooks/Test Medium Blog Post.ipynb', gistify=True)
+    return p
+
+
 class TestPost:
 
     def test_post(self):
         jtm.publish('tests/notebooks/Test Medium Blog Post.ipynb')
-
-
-# def gistify_test_post():
-#    p = publish('tests/notebooks/Test Medium Blog Post.ipynb', gistify=True)
-#    return p


### PR DESCRIPTION
Closes https://github.com/dexplo/jupyter_to_medium/issues/28

PR for adding the option to auto-gist all codeblocks from the .md above a certain threshold line length

I have:
 - Added the option to the form.html (defaults to false so behaviour unchanged)
 - Added the kwarg stripping to the bundler function
 - Added a _postprocessor.py file with the functions to handle the gist creation
 - Added a gistify_markdown method to the Publish class
 - Added the info the README that to use the new 'feature' you need a Github Account and Github access token

Let me know what you think - this is my first PR to some else's repo so let me know if you need anything else. I've tested it both on my own notebooks as well as the test notebook in the lib (I used `pip install -e .` to test the package locally), but am not too familiar with testing frameworks.

If you want I can check up on pytest and write a proper assertion based test for a dummy test notebook. Thanks again for all the work you've done here - it's a real time saver vs. playing around with the medium editor!