### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,9 @@ numpy = "^1.21.4"
 requests = "^2.26.0"
 jupyter-contrib-nbextensions = "^0.5.1"
 jupyter = "^1.0.0"
+jinja = "<=2.11.3"
+markupsafe = "<=2.0.1"
+
 
 [tool.poetry.dev-dependencies]
 flake8 = "^4.0.1"


### PR DESCRIPTION
Added two dependencies with their appropriate version requirements. The package wouldn't work without them from the terminal in Python==3.10.2.

Adding these dependencies with the versions fixed the problem. Several of the required modules from the packages had either been renamed or removed in updates.