### PR TITLE
Fixed PNG syntax error. Fixed issue with .jpg filenames

### DIFF
--- a/src/jupyter_to_medium/_screenshot.py
+++ b/src/jupyter_to_medium/_screenshot.py
@@ -111,25 +111,24 @@ class Screenshot:
         with open(temp_html, "w") as f:
             f.write(self.html)
 
-        with open(temp_img, "wb") as f:
-            args = ["--enable-logging", "--disable-gpu", "--headless"]
+        args = ["--enable-logging", "--disable-gpu", "--headless"]
 
-            if self.ss_width and self.ss_height:
-                args.append(f"--window-size={self.ss_width},{self.ss_height}")
+        if self.ss_width and self.ss_height:
+            args.append(f"--window-size={self.ss_width},{self.ss_height}")
 
-            args += [
-                "--hide-scrollbars",
-                f"--screenshot={str(temp_img)}",
-                str(temp_html),
-            ]
+        args += [
+            "--hide-scrollbars",
+            f"--screenshot={str(temp_img)}",
+            str(temp_html),
+        ]
 
-            subprocess.run(executable=self.chrome_path, args=args)
+        subprocess.run(executable=self.chrome_path, args=args)
 
         with open(temp_img, "rb") as f:
             img_bytes = f.read()
 
         buffer = io.BytesIO(img_bytes)
-        img = mimage.imread(buffer)
+        img = mimage.imread(buffer, format="png")
         return self.possibly_enlarge(img)
 
     def possibly_enlarge(self, img):


### PR DESCRIPTION
Fixes  [Issue #63](https://github.com/dexplo/jupyter_to_medium/issues/63)

Also fixes this issue with medium not understanding file names with .jpg extension:

```Traceback (most recent call last):
  File "C:\Users\indez\.venvs\jtm_dev\lib\site-packages\jupyter_to_medium\_publish_to_medium.py", line 249, in load_images_to_medium
    new_url = req_json["data"]["url"]
KeyError: 'data'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "C:\Users\indez\jupyter_to_medium\publish.py", line 3, in <module>
    jtm.publish(
  File "C:\Users\indez\.venvs\jtm_dev\lib\site-packages\jupyter_to_medium\_publish_to_medium.py", line 465, in publish
    p.main()
  File "C:\Users\indez\.venvs\jtm_dev\lib\site-packages\jupyter_to_medium\_publish_to_medium.py", line 338, in main
    self.load_images_to_medium()
  File "C:\Users\indez\.venvs\jtm_dev\lib\site-packages\jupyter_to_medium\_publish_to_medium.py", line 251, in load_images_to_medium
    raise ValueError("Problem loading image {name}.{extension} to Medium: " + r.text)
ValueError: Problem loading image {name}.{extension} to Medium: {"errors":[{"message":"The media is not in a format we understand.","code":-1}]}
````
The easiest fix for the above would be in the nbconvert package where these file names are generated, but to keep the solution in this repo the markdown and filenames must be corrected after they are generated.